### PR TITLE
Enable Sending Events to Twitch

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,10 @@
+.PHONY: install uninstall clean
+
+install:
+	pip install .
+
+uninstall:
+	pip uninstall twitchobserver
+
+clean:
+	find . -name "*.pyc" -delete


### PR DESCRIPTION
## Overview
This is my first pass at sending events back to Twitch.

## Changes
- Added makefile for quality of life
- TwitchChatEvents now have a dumps method that serializes them out
- Added send methods to TwitchChatObserver
  - notify(event) async
  - send_events(*events) sync
- TwitchChatObserver has two worker threads. One for inbound messages and the other for outbound.
- Set a timeout for the socket communication (way more responsive!)