### PR TITLE
Adding wrapper for send methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Ignore compiled Python artifacts
 *.pyc
+*.egg-info

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -114,23 +114,23 @@ class TwitchChatObserver(object):
 
                 self._outbound_event_queue.append(event)
 
-    def send_message(self, message):
-        message_event = TwitchChatEvent(self._channel, "PRIVMSG", message)
+    def send_message(self, message, channel):
+        """Sends a message to a channel.
+        """
+
+        message_event = TwitchChatEvent(channel, "PRIVMSG", message)
         self.send_events(message_event)
 
     def join_channel(self, channel):
-        if channel is None:
-            return
-        if channel == self._channel:
-            return
+        """Joins a channel.
+        """
 
         self._channel = channel
         join_event = TwitchChatEvent(self._channel, "JOIN")
         self.send_events(join_event)
 
-    def leave_channel(self):
-        leave_event = TwitchChatEvent(self._channel, "PART")
-        self._channel = None
+    def leave_channel(self, channel):
+        leave_event = TwitchChatEvent(channel, "PART")
         self.send_events(leave_event)
 
     def start(self):
@@ -234,7 +234,8 @@ class TwitchChatObserver(object):
         self._outbound_worker_thread = threading.Thread(target=outbound_worker)
         self._outbound_worker_thread.start()
 
-        self.join_channel(self._channel)
+        if self._channel:
+            self.join_channel(self._channel)
 
     def stop(self, force_stop=False):
         """Stops the observer

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -118,22 +118,19 @@ class TwitchChatObserver(object):
         """Sends a message to a channel.
         """
 
-        message_event = TwitchChatEvent(channel, "PRIVMSG", message)
-        self.send_events(message_event)
+        self.send_events(TwitchChatEvent(channel, "PRIVMSG", message))
 
     def join_channel(self, channel):
         """Joins a channel.
         """
 
-        join_event = TwitchChatEvent(channel, "JOIN")
-        self.send_events(join_event)
+        self.send_events(TwitchChatEvent(channel, "JOIN"))
 
     def leave_channel(self, channel):
         """Leaves a channel.
         """
         
-        leave_event = TwitchChatEvent(channel, "PART")
-        self.send_events(leave_event)
+        self.send_events(TwitchChatEvent(channel, "PART"))
 
     def start(self):
         """Starts the observer


### PR DESCRIPTION
## Summary
Adding wrapper for send_events():
- send_message()
- join_channel()
- leave_channel()

Furthermore there was a duplicating '#' in the fetched channel name.