### PR TITLE
Adding Observer Alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ To get Twitch chat events, you create an Observer that monitors a given channel.
 *Note:* To get an OAuth token visit: http://twitchapps.com/tmi/
 
 ```python
-from twitchobserver import TwitchChatObserver
+from twitchobserver import Observer
 
-observer = TwitchChatObserver('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
+observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
 ```
 
 ### 3. Get Events
 
-The TwitchChatObserver class has methods to handle events both synchronously and asynchronously.
+The Observer class has methods to handle events both synchronously and asynchronously.
 
 #### a. Synchronous
 
-The ```TwitchChatObserver.get_events()``` method returns a sequence of ```TwitchChatEvents``` for processing.
+The ```Observer.get_events()``` method returns a sequence of ```ChatEvents``` for processing.
 
 ```python
 observer.start()
@@ -61,7 +61,7 @@ observer.stop()
 
 #### b. Asynchronous
 
-The ```TwitchChatObserver.subscribe(callback)``` method takes a callback that is invoked when Twitch chat messages are recieved. 
+The ```Observer.subscribe(callback)``` method takes a callback that is invoked when Twitch chat messages are recieved. 
 
 ```python
  def event_handler(event):
@@ -75,7 +75,7 @@ The ```TwitchChatObserver.subscribe(callback)``` method takes a callback that is
 
 ### 4. Send Events
 
-```TwitchChatObserver``` provides three methods to make talking to Twitch super easy.
+```Observer``` provides three methods to make talking to Twitch super easy.
 
 #### Sending Messages
 
@@ -103,13 +103,13 @@ observer.leave_channel('channel')
 
 #### Polling for Events
 
-Whenever a viewer joins chat, print out a greeting. The ```TwitchChatObserver``` is created as a [context manager object](https://docs.python.org/3/reference/datamodel.html#context-managers) which will implicitly handle calling ```start()``` and ```stop()```.
+Whenever a viewer joins chat, print out a greeting. The ```Observer``` is created as a [context manager object](https://docs.python.org/3/reference/datamodel.html#context-managers) which will implicitly handle calling ```start()``` and ```stop()```.
 
 ```python
 import time
-from twitchobserver import TwitchChatObserver
+from twitchobserver import Observer
 
-with TwitchChatObserver('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel') as observer:
+with Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel') as observer:
     while True:
         try:
             for event in observer.get_events():
@@ -128,7 +128,7 @@ Allow viewers to cast either a ```!yes``` or ```!no``` vote and tally the result
 
 ```python
 import time
-from twitchobserver import TwitchChatObserver
+from twitchobserver import Observer
 
 votes = {}
 
@@ -143,7 +143,7 @@ def handle_event(event):
         votes[event.nickname] = -1
         
 
-observer = TwitchChatObserver('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
+observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
 observer.subscribe(handle_event)
 
 observer.send_message('Voting has started!', 'channel')

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,7 +7,7 @@ if sys.version_info[0] == 3:
 else:
     import mock
 
-from twitchobserver import TwitchChatObserver
+from twitchobserver import Observer
 
 SUCCESSFUL_LOGIN_MESSAGE = """:tmi.twitch.tv 001 nickname :Welcome, GLHF!\r
 :tmi.twitch.tv 002 nickname :Your host is tmi.twitch.tv\r
@@ -29,7 +29,7 @@ class B(unittest.TestCase):
         with mock.patch('socket.socket') as mock_socket:
             mock_socket.return_value.recv.return_value = SUCCESSFUL_LOGIN_MESSAGE
 
-            observer = TwitchChatObserver('nickname', 'password123', 'channel')
+            observer = Observer('nickname', 'password123', 'channel')
             observer.start()
 
             self.assertEqual(observer._nickname, 'nickname', 'Nickname should be set')
@@ -50,7 +50,7 @@ class B(unittest.TestCase):
             mock_socket.return_value.recv.return_value = UNSUCCESSFUL_LOGIN_MESSAGE
 
             with self.assertRaises(RuntimeError):
-                observer = TwitchChatObserver('nickname', 'password123', 'channel')
+                observer = Observer('nickname', 'password123', 'channel')
                 observer.start()
                 observer.stop(force_stop=True)
 
@@ -58,7 +58,7 @@ class B(unittest.TestCase):
         with mock.patch('socket.socket') as mock_socket:
             mock_socket.return_value.recv.side_effect = [SUCCESSFUL_LOGIN_MESSAGE, SERVER_PING_MESSAGE]
 
-            observer = TwitchChatObserver('nickname', 'password123', 'channel')
+            observer = Observer('nickname', 'password123', 'channel')
             observer.start()
             self.assertEqual(mock_socket.return_value.send.call_args[0][0], CLIENT_PONG_MESSAGE, 'Client should respond with PONG response')
             observer.stop(force_stop=True)

--- a/twitchobserver/__init__.py
+++ b/twitchobserver/__init__.py
@@ -1,3 +1,4 @@
-from .twitchobserver import TwitchChatObserver, TwitchChatEvent
+from .twitchobserver import TwitchChatObserver as Observer
+from .twitchobserver import TwitchChatEvent as ChatEvent
 
 __version__ = "0.1.0"


### PR DESCRIPTION
Quality of life improvement to alias TwitchChatEventObserver and TwitchChatEvent as Observer and ChatEvent.

To be clear, this isn't a rename. Just changing the import in the package __init__.py file.