### PR TITLE
Hopefully fixes JoshuaSkelly/twitch-observer#8 issue with inbound worker callback exceptions

### DIFF
--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -1,3 +1,4 @@
+import sys
 import re
 import socket
 import threading
@@ -78,7 +79,11 @@ class TwitchChatObserver(object):
 
     def _notify_subscribers(self, *args, **kwargs):
         for callback in self._subscribers:
-            callback(*args, **kwargs)
+            try:
+                callback(*args, **kwargs)
+            except:
+                error_type, error_value, error_traceback = sys.exc_info()
+                print("WARN: While calling _notify_subscribers an exception occured in the callback '{}': {}: {}".format(callback.__name__, error_type, error_value))
 
     def get_events(self):
         """Returns a sequence of events since the last time called.

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -3,6 +3,7 @@ import re
 import socket
 import threading
 import time
+import warnings
 
 
 class BadTwitchChatEvent(Exception):
@@ -83,7 +84,7 @@ class TwitchChatObserver(object):
                 callback(*args, **kwargs)
             except:
                 error_type, error_value, error_traceback = sys.exc_info()
-                print("WARN: While calling _notify_subscribers an exception occured in the callback '{}': {}: {}".format(callback.__name__, error_type, error_value))
+                warnings.warn(RuntimeWarning("Callback '{}' raised an error: {}: {}".format(callback.__name__, error_type.__name__, error_value)))
 
     def get_events(self):
         """Returns a sequence of events since the last time called.


### PR DESCRIPTION
## Summary
Wraps calling the callback methods in a try ... except clause to catch any error that is occuring in it.
It also prints out the error to the user.
Is this the behaviour @JoshuaSkelly suggested?