### PR TITLE
Changing badge styles in README.md to flat-square

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # twitch-observer
 
-[![License: GPL v3](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) [![Python 2](https://img.shields.io/badge/python-2-blue.svg)]() [![Python 3](https://img.shields.io/badge/python-3-blue.svg)]()
+[![License: GPL v3](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE) [![Python 2](https://img.shields.io/badge/python-2-blue.svg?style=flat-square)](https://www.python.org/) [![Python 3](https://img.shields.io/badge/python-3-blue.svg?style=flat-square)](https://www.python.org/)
 
 Turn Twitch chatter into Python events.
 


### PR DESCRIPTION
## Summary
- Changing the badge styles in README.md to use the flat-square option instead of the default one
- Adding links to the Python website
- Link to LICENSE no longer broken??

Relates to isse #21 