### PR TITLE
Removing _channel attribute of the TwitchChatObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get Twitch chat events, you create an Observer that monitors a given channel.
 ```python
 from twitchobserver import Observer
 
-observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
+observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123')
 ```
 
 ### 3. Get Events
@@ -47,6 +47,7 @@ The ```Observer.get_events()``` method returns a sequence of ```ChatEvents``` fo
 
 ```python
 observer.start()
+observer.join_channel('channel')
 
 while True:
     try:
@@ -56,6 +57,7 @@ while True:
     except KeyboardInterrupt:
         break
 
+observer.leave_channel('channel')
 observer.stop()
 ```
 
@@ -69,7 +71,11 @@ The ```Observer.subscribe(callback)``` method takes a callback that is invoked w
      
  observer.subscribe(event_handler)
  observer.start()
+ observer.join_channel('channel')
+
  # Wait a while
+
+ observer.leave_channel('channel')
  observer.stop()
 ```
 
@@ -143,7 +149,9 @@ Whenever a viewer joins chat, print out a greeting. The ```Observer``` is create
 import time
 from twitchobserver import Observer
 
-with Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel') as observer:
+with Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123') as observer:
+    observer.join_channel('channel')
+
     while True:
         try:
             for event in observer.get_events():
@@ -153,6 +161,7 @@ with Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel') as obse
             time.sleep(1)
 
         except KeyboardInterrupt:
+            observer.leave_channel('channel')
             break
 ```
 
@@ -177,15 +186,20 @@ def handle_event(event):
         votes[event.nickname] = -1
         
 
-observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123', 'channel')
+observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123')
 observer.subscribe(handle_event)
 
 observer.send_message('Voting has started!', 'channel')
 
 observer.start()
+observer.join_channel('channel')
 time.sleep(60)
+observer.leave_channel('channel')
 observer.stop()
 
+observer = Observer('Nick', 'oauth:abcdefghijklmnopqrstuvwxyz0123')
+observer.start()
+observer.join_channel('channel')
 observer.send_message('Voting is over!', 'channel')
 
 time.sleep(2)
@@ -199,6 +213,9 @@ elif tally < 0:
 
 else:
     observer.send_message('Its a draw!', 'channel')
+
+observer.leave_channel('channel')
+observer.stop()
 ```
 
 ## Contributors

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,12 +29,12 @@ class TestBasicFunctionality(unittest.TestCase):
         with mock.patch('socket.socket') as mock_socket:
             mock_socket.return_value.recv.return_value = SUCCESSFUL_LOGIN_MESSAGE
 
-            observer = Observer('nickname', 'password123', 'channel')
+            observer = Observer('nickname', 'password123')
             observer.start()
+            observer.join_channel('channel')
 
             self.assertEqual(observer._nickname, 'nickname', 'Nickname should be set')
             self.assertEqual(observer._password, 'password123', 'Password should be set')
-            self.assertEqual(observer._channel, 'channel', 'Channel should be set')
             self.assertIsNotNone(observer._inbound_worker_thread, 'Inbound worker thread should be running')
             self.assertIsNotNone(observer._outbound_worker_thread, 'Outbound worker thread should be running')
             self.assertTrue(observer._is_running, 'The observer should be running')
@@ -50,16 +50,18 @@ class TestBasicFunctionality(unittest.TestCase):
             mock_socket.return_value.recv.return_value = UNSUCCESSFUL_LOGIN_MESSAGE
 
             with self.assertRaises(RuntimeError):
-                observer = Observer('nickname', 'password123', 'channel')
+                observer = Observer('nickname', 'password123')
                 observer.start()
+                observer.join_channel('channel')
                 observer.stop(force_stop=True)
 
     def test_server_ping(self):
         with mock.patch('socket.socket') as mock_socket:
             mock_socket.return_value.recv.side_effect = [SUCCESSFUL_LOGIN_MESSAGE, SERVER_PING_MESSAGE]
 
-            observer = Observer('nickname', 'password123', 'channel')
+            observer = Observer('nickname', 'password123')
             observer.start()
+            observer.join_channel('channel')
             self.assertEqual(mock_socket.return_value.send.call_args[0][0], CLIENT_PONG_MESSAGE, 'Client should respond with PONG response')
             observer.stop(force_stop=True)
 

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -95,10 +95,9 @@ class TwitchChatObserver(object):
             is typically the user's nickname.
     """
 
-    def __init__(self, nickname, password, channel=None):
+    def __init__(self, nickname, password):
         self._nickname = nickname
         self._password = password
-        self._channel = channel
         self._subscribers = []
         self._inbound_worker_thread = None
         self._outbound_worker_thread = None
@@ -219,9 +218,6 @@ class TwitchChatObserver(object):
         # Request Twitch-Specific Capabilities
         self._socket.send('CAP REQ :twitch.tv/membership\r\n'.encode('utf-8'))
         self._socket.send('CAP REQ :twitch.tv/commands\r\n'.encode('utf-8'))
-
-        if self._channel:
-            self.join_channel(self._channel)
 
         response = self._socket.recv(1024).decode('utf-8')
         self._socket.settimeout(0.25)


### PR DESCRIPTION
## Summary
- Removing the _channel attribute from the TwitchChatObserver
- Removing support for joining an initial channel when instantiating the observer
- Changing examples in README.md to reflect those changes

Relates to #22 