### PR TITLE
Creating a default TWITCHCHATCOMMAND Type

### DIFF
--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -338,6 +338,7 @@ class TwitchChatObserver(object):
                 event = TwitchChatEvent(command=cmd)
                 event.nickname = nick
                 event._command = cmd
+                event._params = params
 
                 if cmd in ('JOIN', 'PART', 'USERSTATE', 'ROOMSTATE'):
                     event.channel = params[1:]

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -48,11 +48,8 @@ class TwitchChatEvent(object):
         if command in command_to_type:
             self.type = command_to_type[command]
 
-        elif command:
-            self.type = command.upper()
-
         else:
-            self.type = 'TWITCHCHATUNKNOWN'
+            self.type = 'TWITCHCHATCOMMAND'
 
         self.channel = channel
         self._command = command


### PR DESCRIPTION
## Overview

The change here is to improve the event types for the messages that we don't handle. Right now they just show up with the command as the type. This isn't very useful.

I propose to have a basic ```TWITCHCHATCOMMAND``` that represents a server message that we receive, but don't do any special handling around.

Additionally I'm adding a _params attribute to the event so if a consumer of the event is interested in that data, they have it.

## Example Log
event.type: event._command
```
TWITCHCHATCOMMAND: 001
TWITCHCHATCOMMAND: 002
TWITCHCHATCOMMAND: 003
TWITCHCHATCOMMAND: 004
TWITCHCHATCOMMAND: 375
TWITCHCHATCOMMAND: 372
TWITCHCHATCOMMAND: 376
TWITCHCHATCOMMAND: CAP
TWITCHCHATCOMMAND: CAP
```