### PR TITLE
Adding Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "3.6"
+  - "3.6-dev" # 3.6 development branch
+  - "3.7-dev" # 3.7 development branch
+  - "nightly" # currently points to 3.7-dev
+# command to install dependencies
+install: make install-dev-dependencies
+# command to run tests
+script: make test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # twitch-observer
 
-[![License: GPL v3](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE) [![Python 2](https://img.shields.io/badge/python-2-blue.svg?style=flat-square)](https://www.python.org/) [![Python 3](https://img.shields.io/badge/python-3-blue.svg?style=flat-square)](https://www.python.org/)
+[![License: GPL v3](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE) [![Python 2](https://img.shields.io/badge/python-2-blue.svg)](https://www.python.org/) [![Python 3](https://img.shields.io/badge/python-3-blue.svg)](https://www.python.org/) [![Build Status](https://travis-ci.org/JoshuaSkelly/twitch-observer.svg?branch=master)](https://travis-ci.org/JoshuaSkelly/twitch-observer)
 
 Turn Twitch chatter into Python events.
 

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -312,14 +312,6 @@ class TwitchChatObserver(object):
 
         self._is_running = False
 
-        if self._socket:
-            with self._socket_lock:
-                sock = self._socket
-                self._socket = None
-
-                sock.shutdown(socket.SHUT_RDWR)
-                sock.close()
-
         if self._inbound_worker_thread:
             worker = self._inbound_worker_thread
             self._inbound_worker_thread = None
@@ -329,6 +321,14 @@ class TwitchChatObserver(object):
             worker = self._outbound_worker_thread
             self._outbound_worker_thread = None
             worker.join()
+
+        if self._socket:
+            with self._socket_lock:
+                sock = self._socket
+                self._socket = None
+
+                sock.shutdown(socket.SHUT_RDWR)
+                sock.close()
 
     def _process_server_messages(self, response):
         for message in [m for m in response.split('\r\n') if m]:


### PR DESCRIPTION
## Overview

I've created a Travis CI account and added a .travis.yml to the repo root. This is enough to allow Travis CI to pull our code and run our tests.

## Changes
 - Added .travis.yml file
 - Updated README with Travis CI build badge.
 - Fixed Python 2 import issue with unit tests.
 - Removed usage of nonlocal in unit tests (Python 2 compatibility).
 - Fixed race condition in many of the tests. We now call ```observer.stop()``` which will block until the worker threads are done. Then we check the state of the mock socket.
 - Changed the ordering of stopping the observer. Now we wait for both the inbound and outbound threads to join before we shutdown the socket.

## Open Questions

1. Which versions of Python do we care about? Currently we are testing under the below. My concern is testing on the dev versions, which can introduce test failure simply because the builds are a work in progress.
    - Python 2.7
    - Python 3.3
    - Python 3.4
    - Python 3.5
    - Python 3.5-dev
    - Python 3.6
    - Python 3.6-dev
    - Python 3.7-dev
    - Python nightly builds
2. What operating systems do we care about? By default Travis CI only deploys to Linux machines. I think this is fine, I am not aware of any cross platform issues we may have.

@PythooonUser 
Please review these changes. If you think they look okay, I am comfortable with you merging the PR into master. But if you want to talk about my changes first and wait, that is totally fine.