### PR TITLE
Fixing Hanging Issue With Context Manager

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -222,6 +222,12 @@ class TestBasicFunctionality(unittest.TestCase):
         self.observer.start()
         self.assertTrue(self.callback_invoked, 'Subscriber callback should be invoked')
 
+    def test_context_manager_force_stop(self):
+        with Observer('nickname', 'password123') as observer:
+            observer.stop(force_stop=True)
+            self.assertTrue(len(observer._outbound_event_queue) == 0, 'Outbound event queue should be empty')
+            self.assertTrue(len(observer._inbound_event_queue) == 0, 'Inbound event queue should be empty')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/twitchobserver/__init__.py
+++ b/twitchobserver/__init__.py
@@ -1,4 +1,4 @@
 from .twitchobserver import TwitchChatObserver as Observer
 from .twitchobserver import TwitchChatEvent as ChatEvent
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -327,17 +327,23 @@ class TwitchChatObserver(object):
         while self._outbound_event_queue and not force_stop:
             time.sleep(self._outbound_send_interval)
 
+        timeout = None
+        if force_stop:
+            timeout = 0
+
         self._is_running = False
 
         if self._inbound_worker_thread:
             worker = self._inbound_worker_thread
             self._inbound_worker_thread = None
-            worker.join()
+            self._inbound_event_queue = []
+            worker.join(timeout)
 
         if self._outbound_worker_thread:
             worker = self._outbound_worker_thread
             self._outbound_worker_thread = None
-            worker.join()
+            self._outbound_event_queue = []
+            worker.join(timeout)
 
         if self._socket:
             with self._socket_lock:


### PR DESCRIPTION
## Overview
The issue was caused by line 327:

```python
while self._outbound_event_queue and not force_stop:
    time.sleep(self._outbound_send_interval)
```

Calling stop with ```force_stop=True``` would skip waiting for the outbound events to be sent. Then it would stop the workers and do a bit of clean up logic. Then stop gets called a second time by the context manager and will enter an infinite loop if there are still events in the outbound event queue.

## Changes
- Set the event queues to empty when stopping.
- Set the join timeout to ```0``` when forcing a stop.