### PR TITLE
Adding decorator for event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+In this changelog all modifications to the `twitchobserver` beginning from version `0.8.0` are documented.
+
+## [0.8.0] 180704
+### Added
+- Decorator for event handling (suggested by @Senpos)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ More examples can be found in the [Cookbook](https://github.com/JoshuaSkelly/twi
 ---|---
 [Joshua Skelton](http://github.com/joshuaskelly) | [Felix Siebeneicker](https://github.com/pythooonuser)
 
+## Changelog
+For a detailed history of changes made to the twitchobserver see the [changelog](./CHANGELOG.md).
+
 ## License
 MIT
 

--- a/twitchobserver/__init__.py
+++ b/twitchobserver/__init__.py
@@ -3,4 +3,4 @@ from .twitchobserver import TwitchChatEvent as ChatEvent
 from .twitchobserver import TwitchChatEventType as ChatEventType
 from .twitchobserver import TwitchChatColor as ChatColor
 
-__version__ = "0.7.7"
+__version__ = "0.8.0"

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -348,8 +348,6 @@ class TwitchChatObserver(object):
         >>> @observer.on_event(ChatEventType.TWITCHCHATJOIN)
         >>> def handle_join_event(event):
         >>>     print(event.nickname + " joined")
-        >>> 
-        >>> observer.subscribe(handle_join_event)
         """
 
         def decorator(func):

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -342,12 +342,17 @@ class TwitchChatObserver(object):
     def on_event(self, event_type):
         """Decorator for event handlers based on the event type.
 
-        The handler takes an Event as argument.
+        The handler needs to take an event as argument.
         
+        :param event_type: A ChatEventType to listen for
+
         Usage:
-        >>> @observer.on_event(ChatEventType.TWITCHCHATJOIN)
-        >>> def handle_join_event(event):
-        >>>     print(event.nickname + " joined")
+        
+        .. code:: python
+
+            >>> @observer.on_event(ChatEventType.TWITCHCHATJOIN)
+            >>> def handle_join_event(event):
+            >>>     print(event.nickname + " joined")
         """
 
         def decorator(func):

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -353,10 +353,15 @@ class TwitchChatObserver(object):
         """
 
         def decorator(func):
+
             def wrapper(event):
                 if event.type == event_type:
                     return func(event)
+
+            self.subscribe(wrapper)
+
             return wrapper
+
         return decorator
 
     def start(self):

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -339,6 +339,26 @@ class TwitchChatObserver(object):
         else:
             self.send_message("/emoteonlyoff", channel)
 
+    def on_event(self, event_type):
+        """Decorator for event handlers based on the event type.
+
+        The handler takes an Event as argument.
+        
+        Usage:
+        >>> @observer.on_event(ChatEventType.TWITCHCHATJOIN)
+        >>> def handle_join_event(event):
+        >>>     print(event.nickname + " joined")
+        >>> 
+        >>> observer.subscribe(handle_join_event)
+        """
+
+        def decorator(func):
+            def wrapper(event):
+                if event.type == event_type:
+                    return func(event)
+            return wrapper
+        return decorator
+
     def start(self):
         """Starts the observer.
 


### PR DESCRIPTION
## Summary
As requested by #56 this PR adds decorator support for event handlers.

Usage:
```python
>>> @observer.on_event(ChatEventType.TWITCHCHATJOIN)
>>> def handle_join_event(event):
>>>     print(event.nickname + " joined")
```