### PR TITLE
Adding support for the marker command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@ In this changelog all modifications to the `twitchobserver` beginning from versi
 ## [0.8.0] 180704
 ### Added
 - Decorator for event handling (suggested by @Senpos)
+
+## [0.9.0] 180708
+### Added
+- Support for the `/marker` command

--- a/twitchobserver/__init__.py
+++ b/twitchobserver/__init__.py
@@ -3,4 +3,4 @@ from .twitchobserver import TwitchChatEvent as ChatEvent
 from .twitchobserver import TwitchChatEventType as ChatEventType
 from .twitchobserver import TwitchChatColor as ChatColor
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/twitchobserver/twitchobserver.py
+++ b/twitchobserver/twitchobserver.py
@@ -339,6 +339,14 @@ class TwitchChatObserver(object):
         else:
             self.send_message("/emoteonlyoff", channel)
 
+    def set_marker(self, channel):
+        """Sets a stream marker for the Twitch Highlight feature.
+
+        :param channel: The channel name
+        """
+
+        self.send_message("/marker", channel)
+
     def on_event(self, event_type):
         """Decorator for event handlers based on the event type.
 


### PR DESCRIPTION
## Summary
This PR adds support for the new Twitch Marker feature, triggered by the `/marker` command in chat.
It is used for the Stream Hightlights feature.